### PR TITLE
bump react-scripts version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "react-scripts": "0.9.0",
+    "react-scripts": "^1.0.7",
     "webpack": "^2.2.0",
     "webpack-dev-server": "^1.16.2"
   },


### PR DESCRIPTION
@gj 
There was a conflict between react-scripts v 0.9.0 and webpack 2.2.0, that created a compilation error. Updating react-scripts version to 1.0.7 or above fixes the conflict. 